### PR TITLE
Add missed variables

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -30,3 +30,13 @@ variable "ttl" {
   default     = "300"
   description = "The TTL of the record to add to the DNS zone to complete certificate validation"
 }
+
+variable "namespace" {
+  type        = string
+  description = "Namespace (e.g. `eg` or `cp`)"
+}
+
+variable "stage" {
+  type        = string
+  description = "Stage (e.g. `prod`, `dev`, `staging`)"
+}


### PR DESCRIPTION
## What
* Add variables missed in `variables.tf`

## Why
* Getting errors when trying to use this module:

_An argument named "namespace" is not expected here._
_An argument named "stage" is not expected here._
